### PR TITLE
feat(Workflow): Update workflow to use new framer-cli package

### DIFF
--- a/.github/framer/Dockerfile
+++ b/.github/framer/Dockerfile
@@ -6,5 +6,7 @@ LABEL com.github.actions.color="gray-dark"
 
 RUN apk update && apk add jq && rm -rf /var/cache/apk/*
 
+RUN yarn global add framer-cli
+
 COPY "entrypoint.sh" "/entrypoint.sh"
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/framer/entrypoint.sh
+++ b/.github/framer/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 
-# FRAMER_TOKEN should already be set
+# Avoid continuing when errors or undefined variables are present
+set -eu
+
+# FRAMER_TOKEN env token should already be set
 sh -c "framer $*"

--- a/.github/framer/entrypoint.sh
+++ b/.github/framer/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# FRAMER_TOKEN should already be set
+sh -c "framer publish --yes $*"

--- a/.github/framer/entrypoint.sh
+++ b/.github/framer/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # FRAMER_TOKEN should already be set
-sh -c "framer publish --yes $*"
+sh -c "framer $*"

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -5,7 +5,7 @@ workflow "Build and Publish" {
 
 action "Build" {
   uses = "./.github/framer"
-  args = ["build", "--yes"]
+  args = ["build"]
 }
 
 action "Publish" {

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -11,6 +11,6 @@ action "Build" {
 action "Publish" {
   uses = "./.github/framer"
   args = ["publish", "--yes"]
-  requires = ["Build"]
+  needs = ["Build"]
   secrets = ["FRAMER_TOKEN"]
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -8,9 +8,15 @@ action "Build" {
   args = ["build"]
 }
 
+action "Publish Filter" {
+  needs = ["Build"]
+  uses = "actions/bin/filter@master"
+  args = "branch master"
+}
+
 action "Publish" {
   uses = "./.github/framer"
   args = ["publish", "--yes"]
-  needs = ["Build"]
+  needs = ["Build", "Publish Filter"]
   secrets = ["FRAMER_TOKEN"]
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,9 +1,16 @@
-workflow "Publish" {
-  resolves = ["Publish Framer Package"]
+workflow "Build and Publish" {
   on = "push"
+  resolves = "Publish"
 }
 
-action "Publish Framer Package" {
+action "Build" {
   uses = "./.github/framer"
+  args = ["build", "--yes"]
+}
+
+action "Publish" {
+  uses = "./.github/framer"
+  args = ["publish", "--yes"]
+  requires = ["Build"]
   secrets = ["FRAMER_TOKEN"]
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,9 +1,9 @@
-workflow "publish-to-private-store" {
-  resolves = ["yarn-publish"]
+workflow "Publish" {
+  resolves = ["Publish Framer Package"]
   on = "push"
 }
 
-action "yarn-publish" {
-  uses = "./.github/registry"
-  secrets = ["NPM_AUTH_TOKEN"]
+action "Publish Framer Package" {
+  uses = "./.github/framer"
+  secrets = ["FRAMER_TOKEN"]
 }

--- a/.github/registry/entrypoint.sh
+++ b/.github/registry/entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-printf "@framer:registry=https://registry.framer.com/\nalways-auth=true\n//registry.framer.com/:_authToken=$NPM_AUTH_TOKEN" > "$HOME/.npmrc"
-chmod 0600 "$HOME/.npmrc"
-
-VERSION=$(yarn info --json | jq '.data["dist-tags"].latest | (split(".") | .[-2] = (.[-2]|tonumber + 1) | join("."))')
-
-sh -c "yarn publish --access=restricted --new-version=${VERSION} --no-git-tag-version $*"

--- a/readme.md
+++ b/readme.md
@@ -2,4 +2,4 @@ GitHub Framer Auto Publishing Action
 
 1. Make sure GitHub Actions is enabled for your repo.
 2. Add these to the root in a `.github` folder.
-3. Add your token from `.npmrc` to your project.
+3. Add your `FRAMER_TOKEN` to your project workflow.

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,9 @@
-GitHub Framer Auto Publishing Action
+GitHub Framer Auto Build and Publishing Action
 
 1. Make sure GitHub Actions is enabled for your repo.
 2. Add these to the root in a `.github` folder.
 3. Add your `FRAMER_TOKEN` to your project workflow.
+
+Whenever a commit is pushed, the GitHub action will build the Framer project. On commits pushed to the `master` branch, the Framer project will additionally be published to the store.
+
+For more documentation about how to configure the Framer CLI, check out the [`framer-cli` package on npm](https://www.npmjs.com/package/framer-cli)


### PR DESCRIPTION
This PR
- Installs `framer-cli` globally
- Updates `entrypoint.sh` to become a simple wrapper around the `framer-cli` (`sh -c "framer $*"`) which allows for more flexible set of actions (like supporting both `build` and `publish`). This conforms to how [other CLI based workflow actions](https://github.com/actions/zeit-now/blob/master/.github/main.workflow?short_path=38ccd07) seem to operate.
- Updates name of workflow/actions
- Adds `build` action

Relates to https://github.com/framer/company/issues/12071